### PR TITLE
chore: update minor versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,19 @@ ascom-alpaca = { version = "1.0.0-beta.3", features = [
   "camera",
   "filterwheel",
 ] }
-async-trait = "0.1.84"
+async-trait = "0.1.85"
 custom_debug = "0.6.2"
 eyre = "0.6.12"
 qhyccd-rs = "0.1.6"
 ndarray = "0.15.6" # TODO: update to 0.16.1 once ascom_alpaca is updated
 parking_lot = "0.12.3"
 strum = "0.26.3"
-tokio = { version = "1.42.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros"] }
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = "0.3.19"
 cfg-if = "1.0.0"
 educe = "0.6.0"
-clap = { version = "4.5.23", features = ["derive"] }
+clap = { version = "4.5.27", features = ["derive"] }
 
 #to make minimal versions happy
 time = "0.3.35"


### PR DESCRIPTION
This PR updates the following dependencies to their latest minor versions:

- async-trait: 0.1.84 -> 0.1.85
- tokio: 1.42.0 -> 1.43.0
- clap: 4.5.23 -> 4.5.27

All 228 tests are passing. These updates contain only minor version changes and should not introduce any breaking changes.